### PR TITLE
Updates for LaTeXML v0.8.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ RUN eval $(perl -I$HOME/perl5/lib -Mlocal::lib)
 RUN echo 'eval "$(perl -I$HOME/perl5/lib/perl5 -Mlocal::lib)"' >> ~/.bashrc
 
 # Collect the extended ar5iv-bindings files
-ENV AR5IV_BINDINGS_COMMIT=a12a44117b6b7315908d3eb6122f818d7a21390c
+ENV AR5IV_BINDINGS_COMMIT=31337a41074d36750987824b7369ef9e215c4df4
 RUN rm -rf /opt/ar5iv-bindings
 RUN git clone https://github.com/dginev/ar5iv-bindings /opt/ar5iv-bindings
 WORKDIR /opt/ar5iv-bindings
@@ -68,7 +68,7 @@ RUN git reset --hard $AR5IV_BINDINGS_COMMIT
 # Install LaTeXML, at a fixed commit, via cpanminus
 RUN mkdir -p /opt/latexml
 WORKDIR /opt/latexml
-ENV LATEXML_COMMIT=2bfdaf26ab73aea95e210f044762dd4891855b47
+ENV LATEXML_COMMIT=ae2c8b266d1aa04af4350a64c79215bbe4b7c482
 RUN cpanm --notest --verbose https://github.com/brucemiller/LaTeXML/tarball/$LATEXML_COMMIT
 
 # Enable imagemagick policy permissions for work with arXiv PDF/EPS files
@@ -90,11 +90,14 @@ ENV TMPDIR=/dev/shm
 
 # continue as instructed in https://www.howtogeek.com/devops/how-to-use-docker-to-package-cli-applications/
 ENTRYPOINT ["latexmlc", \
-  "--preload=[nobibtex,ids,localrawstyles,nobreakuntex,magnify=2,zoomout=2,tokenlimit=99999999,iflimit=1499999,absorblimit=1299999,pushbacklimit=599999]latexml.sty", \
+  "--preload=[nobibtex,ids,localrawstyles,nobreakuntex,magnify=1.8,zoomout=1.8,tokenlimit=249999999,iflimit=3599999,absorblimit=1299999,pushbacklimit=599999]latexml.sty", \
   "--preload=ar5iv.sty", \
   "--path=/opt/ar5iv-bindings/bindings", \
   "--path=/opt/ar5iv-bindings/supported_originals", \
   "--format=html5","--pmml","--cmml","--mathtex", \
   "--timeout=2700", \
-  "--nodefaultresources","--css=https://cdn.jsdelivr.net/gh/dginev/ar5iv-css@0.7.6/css/ar5iv.min.css"]
+  "--noinvisibletimes", "--nodefaultresources", \
+  "--css=https://cdn.jsdelivr.net/gh/dginev/ar5iv-css@0.7.9/css/ar5iv.min.css",\
+  "--css=https://cdn.jsdelivr.net/gh/dginev/ar5iv-css@0.7.9/css/ar5iv-fonts.min.css"]
+
 CMD ["--source=main.tex", "--dest=main.html"]

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Use the published dockerhub image (under a Unix OS) as:
 ```bash
 $ docker run -v "$(pwd)":/docdir -w /docdir \
              --user "$(id -u):$(id -g)" \
-             latexml/ar5ivist:2301.01 --source=main.tex --destination=html/main.html
+             latexml/ar5ivist:2402.29 --source=main.tex --destination=html/main.html
 ```
 
 Grab a tea or coffee: the average conversion of an arXiv document today takes ~2 minutes, but ar5iv uses a max timeout of upto ~45 minutes.
@@ -20,6 +20,9 @@ Grab a tea or coffee: the average conversion of an arXiv document today takes ~2
 
 build with:
 ```bash
+$ cd ar5ivist-base
+$ docker build --tag ar5ivist-base:latest .
+$ cd ../ar5ivist
 $ docker build --tag ar5ivist:latest .
 ```
 
@@ -33,6 +36,11 @@ $ docker run -v "$(pwd)":/docdir -w /docdir \
 where `main.tex` is the name of your main document source, and `html/main.html` names the HTML5 destination file, with  an (optional) destination directory.
 
 Note that Docker will not be able to escape from the current directory from which you are running the command, so paths using a leading `../` will not work.
+
+## Container Customization
+
+The `ar5ivist-base` Dockerfile was extracted for easy customization in downstream Dockerfiles. The new `ar5ivist` Dockerfile is a thin wrapper over the base container.
+You can follow that example to create your own Dockerfile, with additional dependencies, or completely reconfigured LaTeXML setup.
 
 ## Troubleshooting
 

--- a/ar5ivist-base/Dockerfile
+++ b/ar5ivist-base/Dockerfile
@@ -1,10 +1,10 @@
-## Dockerfile for ar5ivist, using a fixed LaTeXML commit
+## Dockerfile for ar5ivist-base, using a fixed LaTeXML commit
 ##
 ## build with
 ##
-## $ docker build --tag ar5ivist:latest .
+## $ docker build --tag ar5ivist-base:latest .
 ##
-## run with
+## run with the main ar5ivist Dockerfile:
 ##
 ## $ docker run -v "$(pwd)":/docdir -w /docdir \
 ##              --user "$(id -u):$(id -g)" \
@@ -87,17 +87,3 @@ ENV MAGICK_MAP_LIMIT=1GiB
 ENV MAGICK_TIME_LIMIT=900
 ENV MAGICK_TMPDIR=/dev/shm
 ENV TMPDIR=/dev/shm
-
-# continue as instructed in https://www.howtogeek.com/devops/how-to-use-docker-to-package-cli-applications/
-ENTRYPOINT ["latexmlc", \
-  "--preload=[nobibtex,ids,localrawstyles,nobreakuntex,magnify=1.8,zoomout=1.8,tokenlimit=249999999,iflimit=3599999,absorblimit=1299999,pushbacklimit=599999]latexml.sty", \
-  "--preload=ar5iv.sty", \
-  "--path=/opt/ar5iv-bindings/bindings", \
-  "--path=/opt/ar5iv-bindings/supported_originals", \
-  "--format=html5","--pmml","--cmml","--mathtex", \
-  "--timeout=2700", \
-  "--noinvisibletimes", "--nodefaultresources", \
-  "--css=https://cdn.jsdelivr.net/gh/dginev/ar5iv-css@0.7.9/css/ar5iv.min.css",\
-  "--css=https://cdn.jsdelivr.net/gh/dginev/ar5iv-css@0.7.9/css/ar5iv-fonts.min.css"]
-
-CMD ["--source=main.tex", "--dest=main.html"]

--- a/ar5ivist/Dockerfile
+++ b/ar5ivist/Dockerfile
@@ -1,0 +1,29 @@
+## Dockerfile for ar5ivist, using a fixed LaTeXML commit
+##
+## build with
+## $ cd ar5ivist-base
+## $ docker build --tag ar5ivist-base:latest .
+## $ cd ../ar5ivist
+## $ docker build --tag ar5ivist:latest .
+##
+## run with
+##
+## $ docker run -v "$(pwd)":/docdir -w /docdir \
+##              --user "$(id -u):$(id -g)" \
+##              ar5ivist:latest --source=main.tex --destination=html/main.html
+
+FROM ar5ivist-base
+
+# continue as instructed in https://www.howtogeek.com/devops/how-to-use-docker-to-package-cli-applications/
+ENTRYPOINT ["latexmlc", \
+  "--preload=[nobibtex,ids,localrawstyles,nobreakuntex,magnify=1.8,zoomout=1.8,tokenlimit=249999999,iflimit=3599999,absorblimit=1299999,pushbacklimit=599999]latexml.sty", \
+  "--preload=ar5iv.sty", \
+  "--path=/opt/ar5iv-bindings/bindings", \
+  "--path=/opt/ar5iv-bindings/supported_originals", \
+  "--format=html5","--pmml","--cmml","--mathtex", \
+  "--timeout=2700", \
+  "--noinvisibletimes", "--nodefaultresources", \
+  "--css=https://cdn.jsdelivr.net/gh/dginev/ar5iv-css@0.7.9/css/ar5iv.min.css",\
+  "--css=https://cdn.jsdelivr.net/gh/dginev/ar5iv-css@0.7.9/css/ar5iv-fonts.min.css"]
+
+CMD ["--source=main.tex", "--dest=main.html"]


### PR DESCRIPTION
Fixes #3 .

As requested by the arXiv team, this PR also splits the container into two separate Dockerfiles, which allows for easier downstream customization.

The dependency commit shas have been updated to the fresh LaTeXML v0.8.8 release, alongside with tracking the ar5iv-bindings and ar5iv-css repositories.

I will merge and proceed to push properly tagged `2402.29` versions to DockerHub.