### PR TITLE
update ar5ivist to precompiled latex kernel

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Use the published dockerhub image (under a Unix OS) as:
 ```bash
 $ docker run -v "$(pwd)":/docdir -w /docdir \
              --user "$(id -u):$(id -g)" \
-             latexml/ar5ivist:2402.29 --source=main.tex --destination=html/main.html
+             latexml/ar5ivist:2509.16 --source=main.tex --destination=html/main.html
 ```
 
 Grab a tea or coffee: the average conversion of an arXiv document today takes ~2 minutes, but ar5iv uses a max timeout of upto ~45 minutes.

--- a/ar5ivist-base/Dockerfile
+++ b/ar5ivist-base/Dockerfile
@@ -58,7 +58,7 @@ RUN eval $(perl -I$HOME/perl5/lib -Mlocal::lib)
 RUN echo 'eval "$(perl -I$HOME/perl5/lib/perl5 -Mlocal::lib)"' >> ~/.bashrc
 
 # Collect the extended ar5iv-bindings files
-ENV AR5IV_BINDINGS_COMMIT=940ef38c88c813196972e9abd9acd265bf44d98e
+ENV AR5IV_BINDINGS_COMMIT=847b4835448d17065d612c04b52c4a373ec0fd15
 RUN rm -rf /opt/ar5iv-bindings
 RUN git clone https://github.com/dginev/ar5iv-bindings /opt/ar5iv-bindings
 WORKDIR /opt/ar5iv-bindings

--- a/ar5ivist-base/Dockerfile
+++ b/ar5ivist-base/Dockerfile
@@ -10,7 +10,7 @@
 ##              --user "$(id -u):$(id -g)" \
 ##              ar5ivist:latest --source=main.tex --destination=html/main.html
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 # Install the texlive toolchain first (v2021 in Ubuntu 22.04)
 # as it largely stays constant in the background.
@@ -58,7 +58,7 @@ RUN eval $(perl -I$HOME/perl5/lib -Mlocal::lib)
 RUN echo 'eval "$(perl -I$HOME/perl5/lib/perl5 -Mlocal::lib)"' >> ~/.bashrc
 
 # Collect the extended ar5iv-bindings files
-ENV AR5IV_BINDINGS_COMMIT=5bd5cf030c667f4d29dd48d8cfd5874499e4491c
+ENV AR5IV_BINDINGS_COMMIT=940ef38c88c813196972e9abd9acd265bf44d98e
 RUN rm -rf /opt/ar5iv-bindings
 RUN git clone https://github.com/dginev/ar5iv-bindings /opt/ar5iv-bindings
 WORKDIR /opt/ar5iv-bindings
@@ -67,7 +67,7 @@ RUN git reset --hard $AR5IV_BINDINGS_COMMIT
 # Install LaTeXML, at a fixed commit, via cpanminus
 RUN mkdir -p /opt/latexml
 WORKDIR /opt/latexml
-ENV LATEXML_COMMIT=b0c61850a6611abc2418023c6216e5449ad8167f
+ENV LATEXML_COMMIT=25ec2b0e9070cc05cbb5e5e22bebf5ba98a0d86c
 RUN cpanm --notest --verbose --build-args formats https://github.com/brucemiller/LaTeXML/archive/${LATEXML_COMMIT}.zip
 
 # Enable imagemagick policy permissions for work with arXiv PDF/EPS files

--- a/ar5ivist-base/Dockerfile
+++ b/ar5ivist-base/Dockerfile
@@ -67,8 +67,8 @@ RUN git reset --hard $AR5IV_BINDINGS_COMMIT
 # Install LaTeXML, at a fixed commit, via cpanminus
 RUN mkdir -p /opt/latexml
 WORKDIR /opt/latexml
-ENV LATEXML_COMMIT=5e47b3b13a386826581a31464083086520ca2817
-RUN cpanm --notest --verbose https://github.com/brucemiller/LaTeXML/archive/${LATEXML_COMMIT}.zip
+ENV LATEXML_COMMIT=b0c61850a6611abc2418023c6216e5449ad8167f
+RUN cpanm --notest --verbose --build-args formats https://github.com/brucemiller/LaTeXML/archive/${LATEXML_COMMIT}.zip
 
 # Enable imagemagick policy permissions for work with arXiv PDF/EPS files
 RUN perl -pi.bak -e 's/rights="none" pattern="([XE]?PS\d?|PDF)"/rights="read|write" pattern="$1"/g' /etc/ImageMagick-6/policy.xml

--- a/ar5ivist/Dockerfile
+++ b/ar5ivist/Dockerfile
@@ -16,14 +16,14 @@ FROM ar5ivist-base:latest
 
 # continue as instructed in https://www.howtogeek.com/devops/how-to-use-docker-to-package-cli-applications/
 ENTRYPOINT ["latexmlc", \
-  "--preload=[nobibtex,localrawstyles,nobreakuntex,magnify=1.2,zoomout=1.2,tokenlimit=249999999,iflimit=3599999,absorblimit=1299999,pushbacklimit=599999]latexml.sty", \
+  "--preload=[nobibtex,localrawstyles,nobreakuntex,magnify=1.3,zoomout=1.3,tokenlimit=249999999,iflimit=3599999,absorblimit=1299999,pushbacklimit=599999]latexml.sty", \
   "--preload=ar5iv.sty", \
   "--path=/opt/ar5iv-bindings/bindings", \
   "--path=/opt/ar5iv-bindings/supported_originals", \
   "--format=html5","--pmml","--mathtex", \
   "--timeout=2700", \
   "--noinvisibletimes", "--nodefaultresources", \
-  "--css=https://cdn.jsdelivr.net/gh/dginev/ar5iv-css@0.8.1/css/ar5iv.min.css",\
-  "--css=https://cdn.jsdelivr.net/gh/dginev/ar5iv-css@0.8.1/css/ar5iv-fonts.min.css"]
+  "--css=https://cdn.jsdelivr.net/gh/dginev/ar5iv-css@0.8.3/css/ar5iv.min.css",\
+  "--css=https://cdn.jsdelivr.net/gh/dginev/ar5iv-css@0.8.3/css/ar5iv-fonts.min.css"]
 
 CMD ["--source=main.tex", "--dest=main.html"]


### PR DESCRIPTION
Tracks LaTeXML's recent advancements for the v0.9 release.

Keeping this PR as a draft until we stabilize a latexml commit that is well-tested against arXiv.

Sep 12: We are getting closer. Once the latexml "arXiv sandbox" testing phase is completed and the v0.8.3 of the ar5iv CSS is released, this PR can get merged.